### PR TITLE
Week05_jungyi

### DIFF
--- a/MemberRepository.java
+++ b/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.umc9th.domain.member.repository;
+
+import com.example.umc9th.domain.store.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+    Optional<Member> findByUsername(String username);
+}

--- a/MissionRepository.java
+++ b/MissionRepository.java
@@ -1,0 +1,25 @@
+package com.example.umc9th.domain.mission.repository;
+
+import com.example.umc9th.domain.mission.entity.Mission;
+import com.example.umc9th.domain.review.entity.Review;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    // 진행 중 미션 조회
+    List<Mission> findByMemberIdAndStatusOrderByCreateAtDescIdDesc(Long memberId, String status, Pageable pageable);
+
+    // 완료된 미션 조회 (리뷰 포함)
+    @Query(
+            "SELECT m FROM Mission m " +
+                    "LEFT JOIN Review r ON r.member.id = m.member.id AND r.missionTemplateId = m.missionTemplateId " +
+                    "WHERE m.member.id = :memberId " +
+                    "AND m.status = 'end' " +
+                    "ORDER BY m.completedAt DESC, m.id DESC"
+    )
+    List<Mission> findCompletedMissions(@Param("memberId") Long memberId, Pageable pageable);
+}

--- a/MissionTemplateRepository.java
+++ b/MissionTemplateRepository.java
@@ -1,0 +1,26 @@
+package com.example.umc9th.domain.mission.repository;
+
+import com.example.umc9th.domain.mission.entity.MissionTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface MissionTemplateRepository extends JpaRepository<MissionTemplate, Long> {
+
+    @Query(
+            "SELECT mt FROM MissionTemplate mt " +
+                    "JOIN mt.shop s " +
+                    "WHERE s.region.id = :regionId " +
+                    "AND mt.id NOT IN ( " +
+                    "SELECT m.missionTemplateId FROM Mission m " +
+                    "WHERE m.member.id = :memberId " +
+                    "AND m.status IN ('ing', 'end') " +
+                    ") " +
+                    "ORDER BY mt.id DESC"
+    )
+    List<MissionTemplate> findAvailableMissions(@Param("regionId") Long regionId,
+                                                @Param("memberId") Long memberId,
+                                                Pageable pageable);
+}

--- a/ReviewRepository.java
+++ b/ReviewRepository.java
@@ -1,0 +1,10 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.example.umc9th.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    // mission_template_id로 리뷰 조회
+    List<Review> findByMissionTemplateId(Long missionTemplateId);
+}


### PR DESCRIPTION
- 1주차에 SQL로 작성했던 조회 로직을 Spring Data JPA로 리팩토링
- 메서드 네이밍 기반(findBy…)과 @Query(JPQL) 혼합 사용
- 적용 대상: MissionRepository, MissionTemplateRepository, ReviewRepository, MemberRepository